### PR TITLE
Non UUID slugs

### DIFF
--- a/cli/extract/gatsby/src/components/minemap.js
+++ b/cli/extract/gatsby/src/components/minemap.js
@@ -87,7 +87,7 @@ const Row = ({ node, attrs, innerRef, children }) => {
   const handleClick = (event) => {
     // navigate to clicked content or toggle the node open/closed
     if (event.target.dataset.type) {
-      nav(node.data.id.split('|').pop())
+      nav('/' + node.data.id.split('|').pop())
     } else {
       node.toggle()
     }
@@ -95,7 +95,7 @@ const Row = ({ node, attrs, innerRef, children }) => {
 
   const handleKeyDown = (event) => {
     if (event.key === 'Enter') {
-      nav(node.data.id.split('|').pop())
+      nav('/' + node.data.id.split('|').pop())
     }
   }
 

--- a/cli/extract/gatsby/src/components/minemap.js
+++ b/cli/extract/gatsby/src/components/minemap.js
@@ -4,6 +4,7 @@ import { navigate } from 'gatsby'
 import { Tree } from 'react-arborist'
 import { IoCaretDown, IoCaretForward } from 'react-icons/io5'
 import minemapJson from '../../content/minemap.json'
+import slugLookup from '../../content/slug_lookup.json'
 import * as styles from './minemap.module.css'
 
 let rem = 14
@@ -80,7 +81,7 @@ Node.propTypes = {
 
 const Row = ({ node, attrs, innerRef, children }) => {
   const nav = (key) => {
-    navigate('/' + ((key === 'adit') ? '' : key))
+    navigate((key === 'adit') ? '/' : slugLookup[key])
   }
 
   const handleClick = (event) => {

--- a/cli/extract/gatsby/src/components/minemap.js
+++ b/cli/extract/gatsby/src/components/minemap.js
@@ -81,7 +81,7 @@ Node.propTypes = {
 
 const Row = ({ node, attrs, innerRef, children }) => {
   const nav = (key) => {
-    navigate((key === 'adit') ? '/' : slugLookup[key])
+    navigate((key === '/adit') ? '/' : slugLookup[key])
   }
 
   const handleClick = (event) => {

--- a/cli/extract/gatsby/src/components/searchbar.js
+++ b/cli/extract/gatsby/src/components/searchbar.js
@@ -16,7 +16,7 @@ const SearchResults = ({ query, store, index, closeModal }) => {
   return (
     <ul>
       {results && results.map(result => (
-        <li key={result.id}><Link to={'/' + result.slug} onClick={closeModal}>{result.label}</Link></li>
+        <li key={result.id}><Link to={result.slug} onClick={closeModal}>{result.label}</Link></li>
       ))}
     </ul>
   )

--- a/cli/extract/gatsby/src/components/shortcodes.jsx
+++ b/cli/extract/gatsby/src/components/shortcodes.jsx
@@ -46,7 +46,7 @@ const Nugget = withNuggetPropTypes((props) => {
 
   const handleKeyDown = (event) => {
     if (event.key === 'Enter') {
-      nav(props._key)
+      nav(props.slug)
     }
   }
 
@@ -79,7 +79,7 @@ const Seam = withNuggetPropTypes((props) => {
 
   const handleKeyDown = (event) => {
     if (event.key === 'Enter') {
-      nav(props._key)
+      nav(props.slug)
     }
   }
 
@@ -115,7 +115,7 @@ const Passage = withNuggetPropTypes((props) => {
 
   const handleKeyDown = (event) => {
     if (event.key === 'Enter') {
-      nav(props._key)
+      nav(props.slug)
     }
   }
 

--- a/cli/extract/gatsby/src/components/shortcodes.jsx
+++ b/cli/extract/gatsby/src/components/shortcodes.jsx
@@ -30,7 +30,7 @@ function getYaml (props) {
 function nav (key, tagName = '') {
   if (tagName === 'A') return
   if (key === 'adit') navigate('/')
-  else navigate('/' + key)
+  else navigate(key)
 }
 
 const Nugget = withNuggetPropTypes((props) => {
@@ -41,7 +41,7 @@ const Nugget = withNuggetPropTypes((props) => {
   const { globalValue } = useContext(LayoutContext)
 
   const handleClick = (event) => {
-    nav(props._key, event.target.tagName)
+    nav(props.slug, event.target.tagName)
   }
 
   const handleKeyDown = (event) => {
@@ -74,7 +74,7 @@ const Seam = withNuggetPropTypes((props) => {
   const { globalValue } = useContext(LayoutContext)
 
   const handleClick = (event) => {
-    nav(props._key, event.target.tagName)
+    nav(props.slug, event.target.tagName)
   }
 
   const handleKeyDown = (event) => {
@@ -110,7 +110,7 @@ const Passage = withNuggetPropTypes((props) => {
   const { globalValue } = useContext(LayoutContext)
 
   const handleClick = (event) => {
-    nav(props._key, event.target.tagName)
+    nav(props.slug, event.target.tagName)
   }
 
   const handleKeyDown = (event) => {

--- a/cli/extract/gatsby/src/pages/[...].js
+++ b/cli/extract/gatsby/src/pages/[...].js
@@ -1,0 +1,18 @@
+import * as React from 'react'
+import { useLocation } from '@reach/router'
+import { navigate } from 'gatsby'
+import slugLookup from '../../content/slug_lookup.json'
+
+const SlugNav = () => {
+  const path = useLocation().pathname.replace(/\/$/, '')
+
+  if (path in slugLookup) {
+    navigate(slugLookup[path])
+  }
+
+  return (
+    <h1>Nugget not found</h1>
+  )
+}
+
+export default SlugNav

--- a/cli/gatsby.js
+++ b/cli/gatsby.js
@@ -166,7 +166,7 @@ async function extractNuggets (db, dir) {
       paths.slice(1).forEach(e => { slugLookup[e] = paths[0] })
     }
     if (paths.length > 0) {
-      slugLookup[nugget._key] = paths[0]
+      slugLookup['/' + nugget._key] = paths[0]
     }
   }
 

--- a/cli/lib/nugget.js
+++ b/cli/lib/nugget.js
@@ -104,6 +104,10 @@ exports.Nugget = class Nugget {
     delete entries.body
     delete entries.breadcrumbs
 
+    if (!entries.slug) {
+      entries.slug = (entries.paths.length > 0) ? entries.paths[0] : '/'
+    }
+
     // it is decreed that breadcrumbs are not required in outbound vertices
     const breadcrumbs = (entries.direction === 'outbound' || entries.inseam)
       ? ''

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "remark-directive": "^2.0.1",
     "remark-parse": "^10.0.2",
     "remark-stringify": "^10.0.3",
+    "slugify": "^1.6.6",
     "tree-model": "^1.0.7",
     "unist-util-visit-parents": "^5.1.3",
     "uuid": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rakosh",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "yet another knowledge base system -- this time with nuggets",
   "author": "Duncan Rance",
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3604,6 +3604,11 @@ signal-exit@^3.0.0:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
+slugify@^1.6.6:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.6.6.tgz#2d4ac0eacb47add6af9e04d3be79319cbcc7924b"
+  integrity sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==
+
 source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
@@ -3957,7 +3962,7 @@ unist-util-visit-parents@^5.1.1, unist-util-visit-parents@^5.1.3:
     "@types/unist" "^2.0.0"
     unist-util-is "^5.0.0"
 
-unist-util-visit@^4.0.0, unist-util-visit@^4.1.2:
+unist-util-visit@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-4.1.2.tgz#125a42d1eb876283715a3cb5cceaa531828c72e2"
   integrity sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==


### PR DESCRIPTION
Human-readable slugs instead of UUIDs. Navigating to a `/<uuid>` path will redirect to the human-readable slug using client-only routing.

The Arango graph can produce multiple paths for the same Nugget. For now, we're just pulling out the first one to be the primary path/slug. Any other paths will "redirect" to the primary path. 